### PR TITLE
Add Heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 poker-player-js
 ===============
 
-Javascript client skeleton for Lean Poker For more information visit: http://leanpoker.org 
+Javascript client skeleton for Lean Poker For more information visit: http://leanpoker.org
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "Node.js Poker Player",
+  "description": "Javascript client skeleton for Lean Poker",
+  "repository": "https://github.com/lean-poker/poker-player-js",
+  "website": "http://leanpoker.org/",
+  "keywords": ["node", "lean", "poker"]
+}


### PR DESCRIPTION
This magical Heroku deploy button lets devs get set up even faster, they just click the button and it'll build the project for them on Heroku, so that they can get started *immediately*! See [their blog post](https://blog.heroku.com/archives/2014/8/7/heroku-button) for more.