### PR TITLE
Update engines dependency to Node.js prior 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "poker-player-javascript",
     "description": "Javascript player from lean poker. http://leanpoker.org",
     "version": "0.0.2",
+    "engines": {
+        "node": "<4"
+    },
     "private": true,
     "dependencies": {
         "express": "4.x",


### PR DESCRIPTION
Provide this parameter to reflect inability to use ES6 features with this bot to prevent people using `let`, `const` and anything new in the bot code