### PR TITLE
Add one basic unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,15 @@
   "dependencies": {
     "express": "4.x",
     "body-parser": "1.15.2"
+  },
+  "devDependencies": {
+    "chai": "3.x",
+    "mocha": "3.x"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/test/Player_test.js
+++ b/test/Player_test.js
@@ -1,0 +1,10 @@
+var assert = require("assert")
+var Player = require('../Player')
+
+describe("Player", function() {
+  describe("#bet_request", function() {
+    it("should return a number", function() {
+      assert.equal(typeof(Player.betRequest('{}')), "number")
+    })
+  })
+})


### PR DESCRIPTION
Since the Java skeleton starts out with a unit test to check that the
player returns a number I thought it would be fair if the JavaScript
player started with a test too.

I've added the mocha & chai development dependencies for testing locally
(won't be installed in production) and added a "test script" so that you
can conveniently type `npm test` to run the tests.

The tests checks that the Player's betRequest method always returns a
number, even when handed an empty game state.