### PR TITLE
Remove semicolons

### DIFF
--- a/Player.js
+++ b/Player.js
@@ -1,16 +1,16 @@
-const PLAYER_VERSION = '0.1';
+const PLAYER_VERSION = '0.1'
 
 class Player {
   static getVersion() {
-    return PLAYER_VERSION;
+    return PLAYER_VERSION
   }
 
   static betRequest(gameState) {
-    return 0;
+    return 0
   }
 
   static showdown(gameState) {
   }
 }
 
-module.exports = Player;
+module.exports = Player

--- a/player_service.js
+++ b/player_service.js
@@ -1,37 +1,37 @@
-const express = require('express');
-const bodyParser = require('body-parser');
-const http = require('http');
+const express = require('express')
+const bodyParser = require('body-parser')
+const http = require('http')
 
-const app = express();
-const port = parseInt((process.env.PORT || 1337), 10);
-const Player = require('./Player');
+const app = express()
+const port = parseInt((process.env.PORT || 1337), 10)
+const Player = require('./Player')
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: true }))
 
 app.post('/', (req, res) => {
-  const { action, game_state } = req.body;
+  const { action, game_state } = req.body
 
   switch (action) {
     case 'version':
-      res.send(Player.getVersion());
-      break;
+      res.send(Player.getVersion())
+      break
     case 'bet_request':
-      res.json(Player.betRequest(JSON.parse(game_state)));
-      break;
+      res.json(Player.betRequest(JSON.parse(game_state)))
+      break
     case 'showdown':
-      Player.showdown(JSON.parse(game_state));
-      res.send('Ok');
-      break;
+      Player.showdown(JSON.parse(game_state))
+      res.send('Ok')
+      break
     case 'check':
-      res.send('Ok');
-      break;
+      res.send('Ok')
+      break
     default:
-      res.send('Unknown action');
+      res.send('Unknown action')
   }
-});
+})
 
-const server = http.createServer(app);
+const server = http.createServer(app)
 server.listen(port, () => {
-  console.log(`Server listening at: localhost:${port}`);
-});
+  console.log(`Server listening at: localhost:${port}`)
+})


### PR DESCRIPTION
This is personal preference and might conflict with what people fresh
out of coding boot camps expect, so I won't be offended if this doesn't
get merged.

JavaScript has Automatic Semicolon Insertion, so inserting them is
completely unnecessary and people often do it because they're used to
the familiar Java/C/PHP syntax.  In some cases inserting semicolons
yourself can even be a source of unexpected errors.  Therefore I've
removed the semicolons from Player.js and player_service.js to let
JavaScript add the semicolons where needed.